### PR TITLE
[spruce] Bump @pinecone-database version to support global control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,20 @@ export const load = async (csvPath: string, column: string) => {
   // Get index name
   const indexName = getEnv("PINECONE_INDEX");
 
-  // Check whether the index already exists. If it doesn't, create 
-  // a Pinecone index with a dimension of 384 to hold the outputs
-  // of our embeddings model.
-  const indexList = await pinecone.listIndexes();
-  if (indexList.indexOf({ name: indexName }) === -1) {
-    await pinecone.createIndex({ name: indexName, dimension: 384, waitUntilReady: true })
-  }
+  // Create a Pinecone index with a dimension of 384 to hold the outputs
+  // of our embeddings model. Use suppressConflicts in case the index already exists.
+  await pinecone.createIndex({
+    name: indexName,
+    dimension: 384,
+    spec: {
+      serverless: {
+        region: "us-west-2",
+        cloud: "aws",
+      },
+    },
+    waitUntilReady: true,
+    suppressConflicts: true,
+  });
 
   // Select the target Pinecone index. Passing the TextMetadata generic type parameter
   // allows typescript to know what shape to expect when interacting with a record's

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ Copy the template file:
 cp .env.example .env
 ```
 
-And fill in your API key and environment details:
+And fill in your API key and index name:
 
 ```sh
 PINECONE_API_KEY=<your-api-key>
-PINECONE_ENVIRONMENT=<your-environment>
 PINECONE_INDEX=semantic-search
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@pinecone-database/pinecone": "^1.0.0",
+        "@pinecone-database/pinecone": "^1.1.2-spruceDev.20231211000839",
         "@xenova/transformers": "2.0.1",
         "cli-progress": "^3.12.0",
         "dotenv": "^16.0.3",
@@ -91,6 +91,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.0.5.tgz",
+      "integrity": "sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/types": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-2.2.7.tgz",
+      "integrity": "sha512-9MTwGooICP7+ZsX9BTy6YCRzOr4tP6RFRymsc8CaKORfvuAHgLZUQaLwILfQ94tddufVXcBwq637VfEd3ZXbWA==",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -639,23 +658,34 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.0.0.tgz",
-      "integrity": "sha512-CtsfbK4qTDjnS56FVH64FEWNVnhwOyheBlLe3e9T6o9Gaxc00f/079JWUUiZ1lrkc3K/YkmlYYOXbdGyKP2z3A==",
+      "version": "1.1.2-spruceDev.20231211000839",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.2-spruceDev.20231211000839.tgz",
+      "integrity": "sha512-id2Wau1eAP4Eh+CS+4Dg41Zh1gsSG828Li8V4FueHRS81WuIZ0WE37HENG6FUVijVeteG8y19I360rqYJEceHQ==",
       "dependencies": {
-        "@sinclair/typebox": "^0.28.15",
-        "@types/web": "^0.0.99",
+        "@edge-runtime/types": "^2.2.3",
+        "@sinclair/typebox": "^0.29.0",
+        "@types/node": "^18.11.17",
         "ajv": "^8.12.0",
-        "cross-fetch": "^3.1.5"
+        "cross-fetch": "^3.1.5",
+        "encoding": "^0.1.13",
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@pinecone-database/pinecone/node_modules/@sinclair/typebox": {
-      "version": "0.28.20",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.28.20.tgz",
-      "integrity": "sha512-QCF3BGfacwD+3CKhGsMeixnwOmX4AWgm61nKkNdRStyLVu0mpVFYlDSY8gVBOOED1oSwzbJauIWl/+REj8K5+w=="
+      "version": "0.29.6",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
+      "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ=="
+    },
+    "node_modules/@pinecone-database/pinecone/node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@pinecone-database/pinecone/node_modules/ajv": {
       "version": "8.12.0",
@@ -676,6 +706,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@pinecone-database/pinecone/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -827,11 +869,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
       "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
-    },
-    "node_modules/@types/web": {
-      "version": "0.0.99",
-      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.99.tgz",
-      "integrity": "sha512-xMz3tOvtkZzc7RpQrDNiLe5sfMmP+fz8bOxHIZ/U8qXyvzDX4L4Ss1HCjor/O9DSelba+1iXK1VM7lruX28hiQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -1754,6 +1791,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2707,6 +2752,17 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4470,6 +4526,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -5200,6 +5261,11 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:check": "npx prettier --check src"
   },
   "dependencies": {
-    "@pinecone-database/pinecone": "^1.0.0",
+    "@pinecone-database/pinecone": "^1.1.2-spruceDev.20231211000839",
     "@xenova/transformers": "2.0.1",
     "cli-progress": "^3.12.0",
     "dotenv": "^16.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export const run = async () => {
   return parser.parse();
 };
 
-// In case it is not test enviroment run automaticly
+// In case it is not test enviroment run automatically
 /* c8 ignore start */
 if (typeof vitest === "undefined") {
   run();

--- a/src/load.ts
+++ b/src/load.ts
@@ -39,17 +39,20 @@ export const load = async (csvPath: string, column: string) => {
   // Get index name
   const indexName = getEnv("PINECONE_INDEX");
 
-  // Check whether the index already exists. If it doesn't, create
-  // a Pinecone index with a dimension of 384 to hold the outputs
-  // of our embeddings model.
-  const indexList = await pinecone.listIndexes();
-  if (indexList.indexOf({ name: indexName }) === -1) {
-    await pinecone.createIndex({
-      name: indexName,
-      dimension: 384,
-      waitUntilReady: true,
-    });
-  }
+  // Create a Pinecone index with a dimension of 384 to hold the outputs
+  // of our embeddings model. Use suppressConflicts in case the index already exists.
+  await pinecone.createIndex({
+    name: indexName,
+    dimension: 384,
+    spec: {
+      serverless: {
+        region: "us-west-2",
+        cloud: "aws",
+      },
+    },
+    waitUntilReady: true,
+    suppressConflicts: true,
+  });
 
   // Select the target Pinecone index. Passing the TextMetadata generic type parameter
   // allows typescript to know what shape to expect when interacting with a record's

--- a/tests/integration/deleteIndex.test.ts
+++ b/tests/integration/deleteIndex.test.ts
@@ -15,14 +15,22 @@ describe("Delete", () => {
       try {
         const pinecone = new Pinecone();
 
-        const indexList = await pinecone.listIndexes();
-        if (indexList.indexOf({ name: INDEX_NAME }) === -1) {
-          await pinecone.createIndex({ name: INDEX_NAME, dimension: 384, waitUntilReady: true })
-        }
+        await pinecone.createIndex({
+          name: INDEX_NAME,
+          dimension: 384,
+          spec: {
+            serverless: {
+              region: "us-west-2",
+              cloud: "aws",
+            },
+          },
+          waitUntilReady: true,
+          suppressConflicts: true,
+        });
       } catch (error) {
         console.error(error);
       }
-    }, // Set timeout to 5 mins, becouse creating index can take time
+    }, // Set timeout to 5 mins, because creating index can take time
     5 * 60 * 1000
   );
 


### PR DESCRIPTION
## Problem
We've been working to support the new global control plane service in the Pinecone clients. We need to update our sample apps to migrate to the new client versions, and update associated code paths as needed.

`semantic-search-example` is used in `pinecone-ts-client` integration testing in CI, and has been failing since we implemented the new spec.
Example: https://github.com/pinecone-io/pinecone-ts-client/actions/runs/7186352180/job/19572265474

## Solution

- Bump the `@pinecone-database/pinecone` dependency to use the `spruceDev` version of the client: `"^1.1.2-spruceDev.20231211000839"`.
- Update `load.ts` to use `suppressConflicts` properly along with adding relevant configuration fields to the `createIndex()` call.
- Update `semanticSearch.test.ts` to handle the delay in freshness for upserted vectors.
- Comment cleanup.

For now, I've created a `spruce` branch to merge this into as we probably don't want to release sample apps that aren't aligned with what's available publicly.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Test Plan
Run the integration test suite:

`npm run test`
![Screenshot 2023-12-13 at 3 51 08 PM](https://github.com/pinecone-io/semantic-search-example/assets/119623786/0b85d72f-be5d-4d71-b18c-65c0ccd6dcce)


