### PR TITLE
Remove `beforeAll()` global index cleanup from "semantic search" test

### DIFF
--- a/tests/integration/semanticSearch.test.ts
+++ b/tests/integration/semanticSearch.test.ts
@@ -22,15 +22,6 @@ describe(
       return indexName;
     };
 
-    beforeAll(async () => {
-      const pinecone = new Pinecone();
-      const listIndexes = await pinecone.listIndexes();
-      const indexes = listIndexes.indexes || [];
-      for (const index of indexes) {
-        await pinecone.deleteIndex(index.name);
-      }
-    });
-
     afterEach(() => {
       process.argv = originalArgv;
     });


### PR DESCRIPTION
## Problem
The semantic search integration test had a `beforeAll()` hook which was listing and cleaning up _all_ indexes within whatever API key was set. This is error-prone, and a little surprising and destructive if you're testing with a key while not expecting that to happen.

It's also caused flakiness in the external app test in the typescript SDK repo.

## Solution
Remove the `beforeAll()` hook. The `afterAll()` hook is cleaning up any indexes that were loaded/created as a part of the test anyways.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
n/a