### PR TITLE
Resolve default namespaces properly in semanticSearch test

### DIFF
--- a/tests/integration/semanticSearch.test.ts
+++ b/tests/integration/semanticSearch.test.ts
@@ -24,7 +24,7 @@ describe(
 
     const getDefaultNamespaceStats = async (
       namespaces?: Record<string, { recordCount: number }>
-    ) => namespaces?.[""] ?? namespaces?.__default__;
+    ) => namespaces?.[""] ?? namespaces?.["__default__"];
 
     afterEach(() => {
       process.argv = originalArgv;
@@ -81,8 +81,10 @@ describe(
 
       // Ensure that all vectors are added
       if (stats.namespaces) {
-        const defaultNamespaceStats = stats.namespaces[""];
-        expect(defaultNamespaceStats.recordCount).toEqual(4);
+        const defaultNamespaceStats = await getDefaultNamespaceStats(
+          stats.namespaces
+        );
+        expect(defaultNamespaceStats?.recordCount).toEqual(4);
       }
       expect(stats.totalRecordCount).toEqual(4);
 


### PR DESCRIPTION
## Problem
Hard-coded check of `namespaces[""]` failing on upgrade to latest API version. Needs to check for either `""` or `"__default__"`.  

## Solution
Make sure we're checking for both default namespaces everywhere.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
n/a
