### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @pinecone-io/dev-advocates @pinecone-io/sdk


### PR DESCRIPTION
Adds a CODEOWNERS file so review requests (including the maintenance fleet's fix-PRs) route to the owning team(s): `* @pinecone-io/dev-advocates @pinecone-io/sdk`.

Backfill for a repo already in the groundskeeper maintenance fleet's managed set (`.github/managed-repos.json`). A human reviews and merges — this is opened, not merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application or infrastructure code changes; only GitHub review routing configuration.
> 
> **Overview**
> Adds a **`.github/CODEOWNERS`** file so GitHub automatically requests reviews from **`@pinecone-io/dev-advocates`** and **`@pinecone-io/sdk`** for changes under the default `*` rule (the whole repo).
> 
> This is process/governance only—intended to align review routing with the groundskeeper maintenance fleet for repos in the managed set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9560f97b47450ecadc1282dc2d5fbdf2b5285bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->